### PR TITLE
Move Syntax Validation Step from GitHub Workflow to Compile Script

### DIFF
--- a/.github/workflows/compile-check.yaml
+++ b/.github/workflows/compile-check.yaml
@@ -1,4 +1,4 @@
-name: Compile & Check 
+name: Compile & Check
 
 on:
   push:
@@ -6,8 +6,8 @@ on:
   pull_request:
     branches: ["main"]
   workflow_dispatch: # Manual trigger added
-  workflow_call: # Allow other Actions to call this workflow 
-  
+  workflow_call: # Allow other Actions to call this workflow
+
 jobs:
   Compile-and-Check:
     runs-on: windows-latest
@@ -20,9 +20,3 @@ jobs:
       run: |
         Set-ExecutionPolicy Bypass -Scope Process -Force; ./Compile.ps1
       continue-on-error: false # Directly fail the job on error, removing the need for a separate check
-      
-    - name: Check Syntax of winutil.ps1 
-      shell: pwsh
-      run: |
-        Set-ExecutionPolicy Bypass -Scope Process -Force; Get-Command -Syntax .\winutil.ps1 
-      continue-on-error: false

--- a/Compile.ps1
+++ b/Compile.ps1
@@ -132,6 +132,16 @@ else {
 Set-Content -Path $scriptname -Value ($script_content -join "`r`n") -Encoding ascii
 Write-Progress -Activity "Compiling" -Completed
 
+Update-Progress -Activity "Validating" -StatusMessage "Checking winutil.ps1 Syntax" -Percent 0
+Start-Process -FilePath pwsh.exe -ArgumentList '-Command Get-Command -Syntax .\winutil.ps1' -NoNewWindow -Wait -ErrorAction SilentlyContinue -RedirectStandardOutput .\syntax_validation_output.txt
+$syntaxCheckResult = Get-Content .\syntax_validation_output.txt
+Remove-Item .\syntax_validation_output.txt
+if ($syntaxCheckResult -match '\x1b\[(\d+|;)+mGet-Command') {
+    Write-Host "Syntax Validation for 'winutil.ps1' has failed, result of validation:`n$syntaxCheckResult" -ForegroundColor Red
+    exit 1
+}
+Write-Progress -Activity "Validating" -Completed
+
 if ($run){
     try {
         Start-Process -FilePath "pwsh" -ArgumentList ".\$scriptname"


### PR DESCRIPTION
## Type of Change
- [x] Simple improvement

## Testing
Works as expected, and exits with error code `1` upon failing to validate `winutil.ps1` file.

## Additional Information
Simple improvements to PR https://github.com/ChrisTitusTech/winutil/pull/2496

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
